### PR TITLE
Fix AttributeError in CheckPrivilegeNode.render

### DIFF
--- a/privileges/templatetags/privileges_tags.py
+++ b/privileges/templatetags/privileges_tags.py
@@ -1,6 +1,6 @@
 from django import template
 
-import privileges
+from privileges.registration import registry
 
 
 register = template.Library()
@@ -29,7 +29,7 @@ class CheckPrivilegeNode(template.Node):
     def render(self, context):
         privilege = self.privilege.resolve(context)
         user = self.user.resolve(context)
-        context[self.varname] = privileges.has_privilege(user, privilege)
+        context[self.varname] = registry.has_privilege(user, privilege)
         return ""
 
 


### PR DESCRIPTION
In the update from 0.1.0a to 0.1, registration code was refactored from **init**.py to registration.py, but privileges_tags was not updated.  

When rendering a template using the check_privilege tag, Django would throw an AttributeError.
